### PR TITLE
Fix enum for updatedStatus in order status request

### DIFF
--- a/Model/AbstractApi.php
+++ b/Model/AbstractApi.php
@@ -186,7 +186,7 @@ class AbstractApi
         $this->sendApiRequest($url, $json);
     }
 
-    public function getOrderStatusEnum($order)
+    public function getUpdatedStatusEnum($order)
     {
         $orderState = $order->getState();
         if ($orderState == 'complete') {
@@ -204,7 +204,7 @@ class AbstractApi
         $json = [
         "orderId" => $order->getIncrementId(),
         "eventTime" => time(),
-        "updatedStatus" => $this->getOrderStatusEnum($order),
+        "updatedStatus" => $this->getUpdatedStatusEnum($order),
         "payment" => $this->paymentPrepere->generatePaymentInfo($order)
       ];
         $url = "https://api.forter-secure.com/v2/status/" . $order->getIncrementId();

--- a/Model/AbstractApi.php
+++ b/Model/AbstractApi.php
@@ -186,12 +186,25 @@ class AbstractApi
         $this->sendApiRequest($url, $json);
     }
 
+    public function getOrderStatusEnum($order)
+    {
+        $orderState = $order->getState();
+        if ($orderState == 'complete') {
+            $orderState = 'COMPLETED';
+        } elseif ($orderState == 'processing') {
+            $orderState = 'PROCESSING';
+        } elseif ($orderState == 'canceled') {
+            $orderState = 'CANCELED_BY_MERCHANT';
+        }
+        return $orderState;
+    }
+
     public function sendOrderStatus($order)
     {
         $json = [
         "orderId" => $order->getIncrementId(),
         "eventTime" => time(),
-        "updatedStatus" => $order->getState(),
+        "updatedStatus" => $this->getOrderStatusEnum($order),
         "payment" => $this->paymentPrepere->generatePaymentInfo($order)
       ];
         $url = "https://api.forter-secure.com/v2/status/" . $order->getIncrementId();

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": [
         "proprietary"
     ],
-    "version": "2.0.40",
+    "version": "2.0.41",
     "authors": [{
         "name": "Forter Dev",
         "email": "support@forter.com",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,5 +7,5 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Forter_Forter" setup_version="2.0.40"/>
+	<module name="Forter_Forter" setup_version="2.0.41"/>
 </config>


### PR DESCRIPTION
This PR fixes the enum value for the `updatedStatus` field in the Order Status Updated request.