### PR TITLE
Correct issue where save is called on history object

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -596,8 +596,9 @@ class Config
     {
         $order->addStatusHistoryComment('Forter: ' . $message)
           ->setIsCustomerNotified(false)
-          ->setEntityName('order')
-          ->save();
+          ->setEntityName('order');
+
+        $order->save();
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug where the `save` method is called on the `history` object rather than the `order`.