### PR TITLE
fix comment history save() bug, and bump composer version

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -596,8 +596,9 @@ class Config
     {
         $order->addStatusHistoryComment('Forter: ' . $message)
           ->setIsCustomerNotified(false)
-          ->setEntityName('order')
-          ->save();
+          ->setEntityName('order');
+
+        $order->save();
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": [
         "proprietary"
     ],
-    "version": "2.0.41",
+    "version": "2.0.42",
     "authors": [{
         "name": "Forter Dev",
         "email": "support@forter.com",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,5 +7,5 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Forter_Forter" setup_version="2.0.41"/>
+	<module name="Forter_Forter" setup_version="2.0.42"/>
 </config>


### PR DESCRIPTION
This PR fixes a bug where `$order->save()` is called on the comment history object instead of the order.