### PR TITLE
v2.4.8.0: Added recommendation notes and corresponding events + changed the default api_version to 2.17 + some minor adjustments

### DIFF
--- a/Block/Adminhtml/Order/View/Tab/Forter.php
+++ b/Block/Adminhtml/Order/View/Tab/Forter.php
@@ -3,9 +3,13 @@
 namespace Forter\Forter\Block\Adminhtml\Order\View\Tab;
 
 use Magento\Backend\Block\Template\Context;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Phrase;
 use Magento\Framework\Registry;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Helper\Admin;
+use Magento\Sales\Model\Order;
+use Forter\Forter\Model\Config as ForterConfig;
 
 /**
  * Class Forter
@@ -15,38 +19,47 @@ class Forter extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder implemen
     \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
-     * order Object
+     * @var OrderInterface
      */
     protected $orderInterface;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var ScopeConfigInterface
      */
     protected $scopeConfig;
 
     /**
-     * invoice constructor.
-     * @param \Magento\Backend\Block\Template\Context $context
-     * @param \Magento\Framework\Registry $registry
-     * @param \Magento\Sales\Api\Data\OrderInterface $orderInterface
-     * @param \Magento\Sales\Helper\Admin $adminHelper
-     * @param array $data
+     * @var ForterConfig
+     */
+    private $forterConfig;
+
+    /**
+     * @method __construct
+     * @param  ScopeConfigInterface $scopeConfig
+     * @param  Context              $context
+     * @param  Registry             $registry
+     * @param  OrderInterface       $orderInterface
+     * @param  Admin                $adminHelper
+     * @param  ForterConfig         $forterConfig
+     * @param  array                $data
      */
     public function __construct(
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        ScopeConfigInterface $scopeConfig,
         Context $context,
         Registry $registry,
         OrderInterface $orderInterface,
         Admin $adminHelper,
+        ForterConfig $forterConfig,
         array $data = []
     ) {
+        parent::__construct($context, $registry, $adminHelper, $data);
         $this->orderInterface = $orderInterface;
         $this->scopeConfig = $scopeConfig;
-        parent::__construct($context, $registry, $adminHelper, $data);
+        $this->forterConfig = $forterConfig;
     }
 
     /**
-     * @return \Magento\Framework\Phrase
+     * @return Phrase
      */
     public function getTabLabel()
     {
@@ -54,7 +67,7 @@ class Forter extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder implemen
     }
 
     /**
-     * @return \Magento\Framework\Phrase
+     * @return Phrase
      */
     public function getTabTitle()
     {
@@ -87,11 +100,21 @@ class Forter extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder implemen
     }
 
     /**
-     * @return \Magento\Sales\Model\Order
+     * @return Order
      */
     public function getOrder()
     {
         $order_id = $this->getRequest()->getParam('order_id');
         return $this->orderInterface->load($order_id);
+    }
+
+    /**
+     * @method getRecommendationMessageByKey
+     * @param  string                        $recommendationKey
+     * @return string
+     */
+    public function getRecommendationMessageByKey($recommendationKey)
+    {
+        return $this->forterConfig->getRecommendationMessageByKey($recommendationKey);
     }
 }

--- a/Model/ForterLoggerMessage.php
+++ b/Model/ForterLoggerMessage.php
@@ -1,23 +1,33 @@
 <?php
+
 namespace Forter\Forter\Model;
+
 /***
  * class ForterLoggerMessage
  * @package Forter\Forter\Model\ForterLoggerMessage
  */
-class ForterLoggerMessage {
+class ForterLoggerMessage
+{
     public $siteId;
     public $orderId;
     public $transactionId = '';
     public $message;
-    public \StdClass $metaData;
-    public function __construct(string $siteId, string $orderId, string $message ) {
+
+    /**
+     * @var StdClass
+     */
+    public $metaData;
+
+    public function __construct(string $siteId, string $orderId, string $message)
+    {
         $this->siteId = $siteId;
         $this->message = $message;
         $this->orderId = $orderId;
         $this->metaData = new \StdClass();
     }
 
-    public function ToJson() {
+    public function ToJson()
+    {
         return json_encode($this);
     }
 }

--- a/Observer/OrderValidation/PaymentPlaceEnd.php
+++ b/Observer/OrderValidation/PaymentPlaceEnd.php
@@ -26,7 +26,7 @@ use Magento\Store\Model\App\Emulation;
  */
 class PaymentPlaceEnd implements ObserverInterface
 {
-    const VALIDATION_API_ENDPOINT = 'https://api.forter-secure.com/v2/orders/';
+    public const VALIDATION_API_ENDPOINT = 'https://api.forter-secure.com/v2/orders/';
 
     /**
      * @var ScopeConfigInterface
@@ -164,7 +164,7 @@ class PaymentPlaceEnd implements ObserverInterface
                     $order = $observer->getEvent()->getPayment()->getOrder();
                     $order->addStatusHistoryComment(__('Forter (pre) Decision: %1', $this->registry->registry('forter_pre_decision')));
                     $order->save();
-                    $message = new ForterLoggerMessage($this->forterConfig->getSiteId(),  $order->getIncrementId(), 'Pre-Auth');
+                    $message = new ForterLoggerMessage($this->forterConfig->getSiteId(), $order->getIncrementId(), 'Pre-Auth');
                     $message->metaData->order = $order->getData();
                     $message->metaData->payment = $order->getPayment()->getData();
                     $this->forterLogger->SendLog($message);
@@ -195,7 +195,7 @@ class PaymentPlaceEnd implements ObserverInterface
                 $order->setForterStatus('error');
                 $order->addStatusHistoryComment(__('Forter (post) Decision: %1', 'error'));
                 $order->save();
-                $message = new ForterLoggerMessage($this->forterConfig->getSiteId(),  $order->getIncrementId(), 'Post-Auth');
+                $message = new ForterLoggerMessage($this->forterConfig->getSiteId(), $order->getIncrementId(), 'Post-Auth');
                 $message->metaData->order = $order->getData();
                 $message->metaData->payment = $order->getPayment()->getData();
                 $message->metaData->decision = $forterResponse->action;
@@ -204,10 +204,11 @@ class PaymentPlaceEnd implements ObserverInterface
             }
 
             $order->setForterStatus($forterResponse->action);
-            $order->addStatusHistoryComment(__('Forter (post) Decision: %1', $forterResponse->action));
+            $order->addStatusHistoryComment(__('Forter (post) Decision: %1%2', $forterResponse->action, $this->forterConfig->getResponseRecommendationsNote($forterResponse)));
             $this->handleResponse($forterResponse->action, $order);
+            $this->abstractApi->triggerRecommendationEvents($forterResponse, $order, 'post');
 
-            $message = new ForterLoggerMessage($this->forterConfig->getSiteId(),  $order->getIncrementId(), 'Post-Auth');
+            $message = new ForterLoggerMessage($this->forterConfig->getSiteId(), $order->getIncrementId(), 'Post-Auth');
             $message->metaData->order = $order->getData();
             $message->metaData->payment = $order->getPayment()->getData();
             $message->metaData->decision = $forterResponse->action;
@@ -231,7 +232,7 @@ class PaymentPlaceEnd implements ObserverInterface
             }
         }
         if ($this->forterConfig->isDebugEnabled()) {
-            $message = new ForterLoggerMessage($order->getStore()->getWebsiteId(),  $order->getIncrementId(), 'Handling Order With Forter');
+            $message = new ForterLoggerMessage($order->getStore()->getWebsiteId(), $order->getIncrementId(), 'Handling Order With Forter');
             $message->metaData->order = $order->getData();
             $message->metaData->payment = $order->getPayment()->getData();
             $message->metaData->forterDecision = $forterDecision;
@@ -279,7 +280,7 @@ class PaymentPlaceEnd implements ObserverInterface
         $currentTime = $this->dateTime->gmtDate();
         $this->forterConfig->log('Increment ID:' . $order->getIncrementId());
         if ($this->forterConfig->isDebugEnabled()) {
-            $message = new ForterLoggerMessage($this->forterConfig->getSiteId(),  $order->getIncrementId(), 'processing message to queue');
+            $message = new ForterLoggerMessage($this->forterConfig->getSiteId(), $order->getIncrementId(), 'processing message to queue');
             $message->metaData->order = $order->getData();
             $message->metaData->payment = $order->getPayment();
             $message->metaData->currentTime = $currentTime;

--- a/Observer/OrderValidation/PaymentPlaceStart.php
+++ b/Observer/OrderValidation/PaymentPlaceStart.php
@@ -28,7 +28,7 @@ class PaymentPlaceStart implements ObserverInterface
     /**
      *
      */
-    const VALIDATION_API_ENDPOINT = 'https://api.forter-secure.com/v2/orders/';
+    public const VALIDATION_API_ENDPOINT = 'https://api.forter-secure.com/v2/orders/';
 
     /**
      * @var Decline
@@ -194,38 +194,39 @@ class PaymentPlaceStart implements ObserverInterface
             $data = $this->requestBuilderOrder->buildTransaction($order, 'BEFORE_PAYMENT_ACTION');
 
             $url = self::VALIDATION_API_ENDPOINT . $order->getIncrementId();
-            $response = $this->abstractApi->sendApiRequest($url, json_encode($data));
+            $forterResponse = $this->abstractApi->sendApiRequest($url, json_encode($data));
 
             $this->abstractApi->sendOrderStatus($order);
 
-            $order->setForterResponse($response);
+            $order->setForterResponse($forterResponse);
 
-            $response = json_decode($response);
+            $forterResponse = json_decode($forterResponse);
 
-            if ($response->status != 'success' || !isset($response->action)) {
+            if ($forterResponse->status != 'success' || !isset($forterResponse->action)) {
                 $this->registry->register('forter_pre_decision', 'error');
                 $order->setForterStatus('error');
-                $message = new ForterLoggerMessage($this->config->getSiteId(),  $order->getIncrementId(), 'Response Error - Pre-Auth');
+                $message = new ForterLoggerMessage($this->config->getSiteId(), $order->getIncrementId(), 'Response Error - Pre-Auth');
                 $message->metaData->order = $order->getData();
                 $message->metaData->payment = $order->getPayment()->getData();
-                $message->metaData->forterDecision = $response->action;
+                $message->metaData->forterDecision = $forterResponse->action;
                 $this->forterLogger->SendLog($message);
                 return;
             }
 
-            $this->registry->register('forter_pre_decision', $response->action);
-            $order->setForterStatus($response->action);
-            $order->addStatusHistoryComment(__('Forter (pre) Decision: %1', $response->action));
-            if ($response->action != 'decline') {
+            $this->registry->register('forter_pre_decision', $forterResponse->action);
+            $order->setForterStatus($forterResponse->action);
+            $order->addStatusHistoryComment(__('Forter (pre) Decision: %1%2', $forterResponse->action, $this->config->getResponseRecommendationsNote($forterResponse)));
+            $this->abstractApi->triggerRecommendationEvents($forterResponse, $order, 'pre');
+            if ($forterResponse->action != 'decline') {
                 return;
             }
         } catch (\Exception $e) {
             $this->abstractApi->reportToForterOnCatch($e);
         }
-        $message = new ForterLoggerMessage($this->config->getSiteId(),  $order->getIncrementId(), 'Handle Response - Pre-Auth');
+        $message = new ForterLoggerMessage($this->config->getSiteId(), $order->getIncrementId(), 'Handle Response - Pre-Auth');
         $message->metaData->order = $order->getData();
         $message->metaData->payment = $order->getPayment()->getData();
-        $message->metaData->forterDecision = $response->action;
+        $message->metaData->forterDecision = $forterResponse->action;
         $this->forterLogger->SendLog($message);
         $this->decline->handlePreTransactionDescision($order);
     }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Magento 2 Forter Fraud Detection Module
 
-Latest ver - 2.0.52 (December 2021)
-
 ---
 
 ## ✓ Install via composer (recommended)

--- a/Ui/Component/Listing/Column/ForterStatus.php
+++ b/Ui/Component/Listing/Column/ForterStatus.php
@@ -7,6 +7,7 @@ use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Ui\Component\Listing\Columns\Column;
+use Forter\Forter\Model\Config as ForterConfig;
 
 /**
  * Class ForterStatus
@@ -15,9 +16,15 @@ use Magento\Ui\Component\Listing\Columns\Column;
 class ForterStatus extends Column
 {
     /**
+     * @var ForterConfig
+     */
+    private $forterConfig;
+
+    /**
      * @var OrderRepositoryInterface
      */
     protected $_orderRepository;
+
     /**
      * @var SearchCriteriaBuilder
      */
@@ -29,6 +36,7 @@ class ForterStatus extends Column
      * @param UiComponentFactory $uiComponentFactory
      * @param OrderRepositoryInterface $orderRepository
      * @param SearchCriteriaBuilder $criteria
+     * @param ForterConfig $forterConfig
      * @param array $components
      * @param array $data
      */
@@ -37,12 +45,14 @@ class ForterStatus extends Column
         UiComponentFactory $uiComponentFactory,
         OrderRepositoryInterface $orderRepository,
         SearchCriteriaBuilder $criteria,
+        ForterConfig $forterConfig,
         array $components = [],
         array $data = []
     ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
         $this->_orderRepository = $orderRepository;
         $this->_searchCriteria = $criteria;
-        parent::__construct($context, $uiComponentFactory, $components, $data);
+        $this->forterConfig = $forterConfig;
     }
 
     /**
@@ -54,10 +64,12 @@ class ForterStatus extends Column
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $order = $this->_orderRepository->get($item["entity_id"]);
-
-                $order_id = $order->getEntityId();
-
-                $item[$this->getData('name')] = $order->getForterStatus();
+                $columnData = $order->getForterStatus();
+                if (($forterResponse = $order->getForterResponse())) {
+                    $forterResponse = json_decode((string) $forterResponse);
+                    $columnData .= $this->forterConfig->getResponseRecommendationsNote($forterResponse, false);
+                }
+                $item[$this->getData('name')] = $columnData;
             }
         }
         return $dataSource;

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,13 @@
     "license": [
         "proprietary"
     ],
-    "version": "2.4.7",
-    "authors": [
-        {
-            "name": "Forter Dev",
-            "email": "support@forter.com",
-            "role": "Developer",
-            "homepage": "https://www.forter.com/"
-        }
-    ],
+    "version": "2.4.8",
+    "authors": [{
+        "name": "Forter Dev",
+        "email": "support@forter.com",
+        "role": "Developer",
+        "homepage": "https://www.forter.com/"
+    }],
     "autoload": {
         "files": [
             "registration.php"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -26,9 +26,6 @@
                 </field>
                 <field id="api_version" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Forter API Version</label>
-                    <comment>
-                        Only change if instructed by Forter.
-                    </comment>
                 </field>
                 <field id="module_version" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Extension Version</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,7 +5,7 @@
             <settings>
                 <enabled>0</enabled>
                 <debug_mode>0</debug_mode>
-                <api_version>2.0</api_version>
+                <api_version>2.17</api_version>
                 <enhanced_data_mode>0</enhanced_data_mode>
                 <sandbox_mode>0</sandbox_mode>
             </settings>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,5 +7,5 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Forter_Forter" setup_version="2.4.7"/>
+	<module name="Forter_Forter" setup_version="2.4.8"/>
 </config>

--- a/view/adminhtml/templates/order/view/tab/forter.phtml
+++ b/view/adminhtml/templates/order/view/tab/forter.phtml
@@ -3,10 +3,9 @@
  * @var Eset\License\Block\Adminhtml\Order\View\Tab\Invoice $block
  */
 $adminOrder = false;
-$order = $this->getOrder();
+$order = $block->getOrder();
 $forterResponse = $order->getData('forter_response');
-$forterResponse = is_null( $forterResponse ) ? [] : json_decode($forterResponse);
-
+$forterResponse = is_null($forterResponse) ? [] : json_decode($forterResponse);
 ?>
 
 <section class="admin__page-section">
@@ -35,7 +34,24 @@ $forterResponse = is_null( $forterResponse ) ? [] : json_decode($forterResponse)
             <span class="title"><?php echo __("Forter Action (Decision)"); ?></span>
         </div>
         <div class="admin__page-section-item-content invoice_item_content">
-            <div class=""><?php echo $forterResponse->action;?></div>
+            <div class=""><?php echo $forterResponse->action ?></div>
+        </div>
+    </div>
+</section>
+<?php endif; ?>
+
+<?php if (!empty($forterResponse->recommendations) && is_array($forterResponse->recommendations)): ?>
+<section class="admin__page-section">
+    <div class="admin__page-section-content">
+        <div class="admin__page-section-item-title invoice_item_title">
+            <span class="title"><?php echo __("Forter Recommendations"); ?></span>
+        </div>
+        <div class="admin__page-section-item-content invoice_item_content">
+            <?php foreach ($forterResponse->recommendations as $recommendation): ?>
+                <?php if ($recommendation && is_string($recommendation)): ?>
+                    <div><?php echo $block->getRecommendationMessageByKey($recommendation) ?> (<?php echo $recommendation; ?>)</div>
+                <?php endif; ?>
+            <?php endforeach; ?>
         </div>
     </div>
 </section>


### PR DESCRIPTION
* Added recommendation notes and corresponding events.
* Changed the default api_version to 2.17.
* Some minor adjustments.
--
For applying custom logics upon an incoming recommendation, they'll need to write a custom module and listen for Forter events.
The event name would be `forter_recommendation_` + the recommendation code as lowercase (e.g., `forter_recommendation_monitor_potential_refund_abuse`).
On their custom observer, they'll have access to the:
`recommendation` = The original recommendation code ("MONITOR_POTENTIAL_REFUND_ABUSE").
`forter_response`   = The full Forter response.
`order`                    = The order object.
`timing`                   = The position in the flow, in which the event has been triggered ("pre" / "post" / "cron").