### PR TITLE
Fix plugin afterFinalizeOrder returns

### DIFF
--- a/Plugin/Thirdparty/Adyen/Helper/Order.php
+++ b/Plugin/Thirdparty/Adyen/Helper/Order.php
@@ -32,7 +32,7 @@ class Order
 
         $forterEntity = $this->entityHelper->getForterEntityByIncrementId($order->getIncrementId());
         if (!$forterEntity) {
-            return;
+            return $order;
         }
         if (
             $forterEntity->getForterStatus() == 'decline' &&


### PR DESCRIPTION
If I have the module installed but disabled at backend this plugin returns nothing.
This breaks Adyen's flow for example when processing CAPTURE notifications.
It should returns the result coming from the original method, so here's my PR that fix it.