### PR TITLE
Feature/added pre auth flow braintree graphql support to cc and applepay

### DIFF
--- a/Model/Mappers/BraintreeMapper.php
+++ b/Model/Mappers/BraintreeMapper.php
@@ -51,6 +51,11 @@ class BraintreeMapper
             $detailsArray['countryOfIssuance'] = $forter_cc_country;
         }
 
+        $lastFourDigits = $payment->getAdditionalInformation('cc_last4');
+        if ($lastFourDigits) {
+            $detailsArray['lastFourDigits'] = $lastFourDigits;
+        }
+
         return $detailsArray;
     }
 

--- a/Observer/ThirdParty/Braintree/BraintreeCcDataAssignObserver.php
+++ b/Observer/ThirdParty/Braintree/BraintreeCcDataAssignObserver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Forter\Forter\Observer\ThirdParty\Braintree\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+
+class BraintreeCcDataAssignObserver extends AbstractDataAssignObserver
+{
+    public const CC_BIN = 'bin';
+    public const CC_LAST4 = 'cc_last4';
+
+    /**
+     * @var array
+     */
+    protected $additionalInformationList = [
+        self::CC_BIN,
+        self::CC_LAST4
+    ];
+
+    /**
+     * Assign additional payment card information
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        $data = $this->readDataArgument($observer);
+
+        $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
+        if (!is_array($additionalData)) {
+            return;
+        }
+
+        $paymentInfo = $this->readPaymentModelArgument($observer);
+
+        foreach ($this->additionalInformationList as $additionalInformationKey) {
+            if (isset($additionalData[$additionalInformationKey])) {
+                $paymentInfo->setAdditionalInformation(
+                    $additionalInformationKey,
+                    $additionalData[$additionalInformationKey]
+                );
+            }
+        }
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -33,5 +33,12 @@
     <event name="payment_method_assign_data_adyen_cc">
         <observer name="forter_adyen_cc_gateway_data_assign" instance="Forter\Forter\Observer\ThirdParty\Adyen\AdyenCcDataAssignObserver" />
     </event>
-
+    <event name="payment_method_assign_data_braintree">
+        <observer name="braintree_gateway_cc_data_assign"
+                  instance="Forter\Forter\Observer\ThirdParty\Braintree\BraintreeCcDataAssignObserver" />
+    </event>
+    <event name="payment_method_assign_data_braintree_applepay">
+        <observer name="braintree_applepay_gateway_cc_data_assign"
+                  instance="Forter\Forter\Observer\ThirdParty\Braintree\BraintreeCcDataAssignObserver" />
+    </event>
 </config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,0 +1,4 @@
+input BraintreeInput {
+    bin: String @doc(description:"Card bin details")
+    cc_last4: String @doc(description:"Card last 4 digits details")
+}


### PR DESCRIPTION
The code changes below will support the Braintree Pre-Auth validation process for passing the credit card details to Forter validation.

cc: @rachel-yankelevitz 