### PR TITLE
Added missing return variable

### DIFF
--- a/Plugin/Thirdparty/Adyen/Helper/Order.php
+++ b/Plugin/Thirdparty/Adyen/Helper/Order.php
@@ -32,7 +32,7 @@ class Order
 
         $forterEntity = $this->entityHelper->getForterEntityByIncrementId($order->getIncrementId());
         if (!$forterEntity) {
-            return;
+            return $order;
         }
         if (
             $forterEntity->getForterStatus() == 'decline' &&


### PR DESCRIPTION
The plugin should return $order variable as is requested by Adyen class and because of this missing variable we have errors during order authorizations